### PR TITLE
res.body seems to the API that has shipped in latest Canary

### DIFF
--- a/cachedb.js
+++ b/cachedb.js
@@ -355,7 +355,7 @@ CacheDBProto.put = function(origin, cacheName, items) {
   return Promise.all(
     items.map(function(item) {
       // item[1].body.asBlob() is the old API
-      return item[1].asBlob ? item[1].asBlob() : item[1].body.asBlob();
+      return item[1].blob ? item[1].blob() : item[1].body.asBlob();
     })
   ).then(function(responseBodies) {
     return this.db.transaction(['cacheEntries', 'cacheNames'], function(tx) {


### PR DESCRIPTION
I might be wrong - but it does seem to work for:-
https://github.com/serviceworker/offline-news-service-worker [ See here https://github.com/serviceworker/offline-news-service-worker/pull/7 ]

Found by poking around at the response object in debugger in Canary:-

![screen shot 2014-09-13 at 01 23 30](https://cloud.githubusercontent.com/assets/825088/4258873/3f974e10-3adc-11e4-92a9-9d344bcf9765.png)

// cc @jakearchibald
