### PR TITLE
Fix "main" property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "serviceworker-cache-polyfill",
   "version": "2.0.0",
   "description": "Cache polyfill for the ServiceWorker",
-  "main": "cache.js",
+  "main": "dist/serviceworker-cache-polyfill.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
I'm trying to use this polyfill in a toy project using [Webpack](http://webpack.github.io/), but the `main` property in `package.json` is pointing at a nonexistent file. I've updated it to point to `dist/serviceworker-cache-polyfill.js ` instead.