### PR TITLE
Remove `Cache.prototype.add`

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,12 +15,6 @@
  *
  */
 
-if (!Cache.prototype.add) {
-  Cache.prototype.add = function add(request) {
-    return this.addAll([request]);
-  };
-}
-
 if (!Cache.prototype.addAll) {
   Cache.prototype.addAll = function addAll(requests) {
     var cache = this;


### PR DESCRIPTION
`Cache.prototype.add` ships in Chrome 44 and Opera 31.

Maybe hold off on merging/releasing this one until Opera 31 is released?