### PR TITLE
Update addAll() to reflect new behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,14 +77,18 @@
         })
       );
     }).then(function(responses) {
+      // If some of the responses has not OK-eish status,
+      // then whole operation should reject
+      if (responses.some(function(response) {
+        return !response.ok;
+      })) {
+        throw new NetworkError('Incorrect response status');
+      }
+
       // TODO: check that requests don't overwrite one another
       // (don't think this is possible to polyfill due to opaque responses)
       return Promise.all(
         responses.map(function(response, i) {
-          if (!response.ok) {
-            throw new NetworkError('Incorrect response status');
-          }
-
           return cache.put(requests[i], response);
         })
       );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serviceworker-cache-polyfill",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Cache polyfill for the ServiceWorker",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Make addAll() fail on responses other than OK in Firefox < 46 and Chrome < 50.
Also, if addAll() had to be fixed even though native exists--polyfill add()
method too. More details at slightlyoff/ServiceWorker#823

Also bumped version to `4.0.0` since it's kind of breaking change. Let me know if this PR seems messy for you, because I have a bit of such feeling (e.g. userAgent checks),