### PR TITLE
Polyfill add() whenever addAll() is polyfilled

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,11 +97,7 @@
     });
   };
 
-  // Has native addAll(), but it has to be fixed anyway.
-  // So add() has to be fixed too
-  if (nativeAddAll) {
-    Cache.prototype.add = function add(request) {
-      return this.addAll([request]);
-    };
-  }
+  Cache.prototype.add = function add(request) {
+    return this.addAll([request]);
+  };
 }());


### PR DESCRIPTION
Even though add() may exist when addAll() isn't, it still has
to be polyfilled, because it has old behavior.
________________________________________

Now everything has to be right :-)