### PR TITLE
Fixed: #25, ReferenceError: Cache is not defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,11 @@
  */
 
 (function() {
+  // if there is no `Cache` on `window` or other global object, like `process`
+  // then we can do nothing, just returns.
+  // fixed #25: https://github.com/dominiccooney/cache-polyfill/issues/25
+  if (!window.Cache) return;
+
   var nativeAddAll = Cache.prototype.addAll;
   var userAgent = navigator.userAgent.match(/(Firefox|Chrome)\/(\d+\.)/);
 


### PR DESCRIPTION
```javascript
ReferenceError: Cache is not defined
```

```javascript
(anonymous function)
internal:///Users/vuchan/Development/WorkSpace/***/node_modules/_serviceworker-cache-polyfill@4.0.0@serviceworker-cache-polyfill/index.js:19
```

```javascript
(function() {
> 19 |   var nativeAddAll = Cache.prototype.addAll;
  20 |   var userAgent = navigator.userAgent.match(/(Firefox|Chrome)\/(\d+\.)/);
  21 | 
  22 |   // Has nice behavior of `var` which everyone hates
```