### PR TITLE
Cache not defined Issue Fixed on Serviceworker-Cache-Pollyfill

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@
  */
 
 (function() {
+  if(typeof Cache == "undefined") {return;}
   var nativeAddAll = Cache.prototype.addAll;
   var userAgent = navigator.userAgent.match(/(Firefox|Chrome)\/(\d+\.)/);
 


### PR DESCRIPTION
You might get "Cache not defined" issue on serviceworker-cache-pollyfill, which was fixed.